### PR TITLE
fixing pg-dumpall version mismatch error by installing PostgreSQL client version 17

### DIFF
--- a/postgres-logical-backup/Dockerfile
+++ b/postgres-logical-backup/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update     \
     && curl --silent https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && apt-get install --no-install-recommends -y  \
+        postgresql-client-17  \
         postgresql-client-16  \
         postgresql-client-15  \
         postgresql-client-14  \


### PR DESCRIPTION
…ent version 17