### PR TITLE
Resolving compatibility issues of postgres-logical-backup with our S3 server

### DIFF
--- a/.github/workflows/postgres-logical-backup.yml
+++ b/.github/workflows/postgres-logical-backup.yml
@@ -25,7 +25,7 @@ jobs:
           images: ghcr.io/obmondo/postgres-logical-backup
           tags: |
             type=raw,value=latest
-            type=semver,pattern={{version}},value=v3.1.8
+            type=semver,pattern={{version}},value=v3.1.9
           flavor: |
             latest=false
       - name: Login to GitHub Container Registry

--- a/postgres-logical-backup/dump.sh
+++ b/postgres-logical-backup/dump.sh
@@ -54,7 +54,9 @@ function aws_delete_objects {
   [[ ! -z "${LOGICAL_BACKUP_S3_ENDPOINT}" ]] && args+=("--endpoint-url=${LOGICAL_BACKUP_S3_ENDPOINT}")
   [[ ! -z "${LOGICAL_BACKUP_S3_REGION}" ]] && args+=("--region=${LOGICAL_BACKUP_S3_REGION}")
 
-  aws s3api delete-objects "${args[@]}" --delete Objects=["$(printf \{Key=%q\}, "$@")"],Quiet=true
+  for key in "$@"; do
+    aws s3api delete-object "${args[@]}" --key "$key"
+  done
 }
 export -f aws_delete_objects
 
@@ -141,5 +143,6 @@ else
   dump | compress | upload
   [[ ${PIPESTATUS[0]} != 0 || ${PIPESTATUS[1]} != 0 || ${PIPESTATUS[2]} != 0 ]] && (( ERRORCOUNT += 1 ))
   set +x
+
   exit $ERRORCOUNT
 fi


### PR DESCRIPTION
issue - https://gitea.obmondo.com/EnableIT/enableit/issues/7067

- there are two commands in aws CLI - ```aws s3api delete-objects``` and ```aws s3api delete-object```
- the script was using ```delete-objects``` command up till now and recently it failed deleting old backups with this error (our Zenko S3 server in atat)
```
An error occurred (BadDigest) when calling the DeleteObjects operation (reached max retries: 4): The Content-MD5 you specified did not match what we received.
xargs: bash: exited with status 255; aborting
```
- found varioius upstream issues reporting the same problem with different S3 servers and some suggested to use  ```aws s3api delete-object``` only
- discussed with divyam and he gave a go ahead with using ```delete-object``` therefore I've made PR for this
- this helps in maintaining compatibility with all the S3 servers