### PR TITLE
fix(hetzner-failover-script): target node public IP, not private hostIP

### DIFF
--- a/hetzner-failover-script/cmd/main.go
+++ b/hetzner-failover-script/cmd/main.go
@@ -51,11 +51,13 @@ func prepare(ctx context.Context) (func(), string, time.Duration) {
 		},
 
 		FailoverIP: utils.GetRequiredEnv("FAILOVER_IP"),
-		ServerIP:   utils.GetRequiredEnv("SERVER_IP"),
+		NodeName:   utils.GetRequiredEnv("NODE_NAME"),
 	}
 
 	function := func() {
-		hetzner.PointFailoverIPToServer(ctx, args)
+		if err := hetzner.PointFailoverIPToServer(ctx, args); err != nil {
+			slog.ErrorContext(ctx, "Failover reconcile failed; will retry next interval", slog.Any("err", err))
+		}
 	}
 
 	tag := "HetznerFailover"

--- a/hetzner-failover-script/pkg/hetzner/failover_ip.go
+++ b/hetzner-failover-script/pkg/hetzner/failover_ip.go
@@ -3,11 +3,11 @@ package hetzner
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"fmt"
 	"log/slog"
 	"net/http"
 
-	assert "github.com/Obmondo/dockerfiles/hetzner-failover-script/pkg/utils"
+	"github.com/Obmondo/dockerfiles/hetzner-failover-script/pkg/kube"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -17,7 +17,7 @@ type (
 	PointFailoverIPToArgs struct {
 		Robot Robot
 		FailoverIP,
-		ServerIP string
+		NodeName string
 	}
 
 	Robot struct {
@@ -28,8 +28,24 @@ type (
 	}
 )
 
-// Makes the given Failover IP point to the server IP.
-func PointFailoverIPToServer(ctx context.Context, args PointFailoverIPToArgs) {
+/*
+	A Failover IP is an additional IP that you can switch from one server to another. You can order
+	it for any Hetzner dedicated root server, and you can switch it to any other Hetzner dedicated
+	root server, regardless of location.
+
+	Switching a Failover IP takes between 90 and 110 seconds.
+
+	REFERENCE : https://docs.hetzner.com/robot/dedicated-server/ip/failover/.
+
+	Hetzner Robot Failover IP API spec : https://robot.hetzner.com/doc/webservice/en.html#failover.
+*/
+
+// PointFailoverIPToServer makes the given Failover IP point to the public IP of the node this pod
+// is running on.
+//
+// Errors are returned (not fatal) so the caller can log and retry on the next interval, instead of
+// crash-looping the process on a transient or misconfigured API call.
+func PointFailoverIPToServer(ctx context.Context, args PointFailoverIPToArgs) error {
 	httpClient := resty.New().
 		SetBaseURL(HETZNER_ROBOT_WEB_SERVICE_API)
 
@@ -41,77 +57,87 @@ func PointFailoverIPToServer(ctx context.Context, args PointFailoverIPToArgs) {
 		httpClient.SetAuthToken(args.Robot.APIToken)
 
 	default:
-		log.Fatalf("Either provide username and password / api token as credentials, to communicate with the Hetzner Robot API")
+		return fmt.Errorf("no Hetzner Robot credentials provided: set a username and password, or an API token")
 	}
 
-	/*
-		A Failover IP is an additional IP that you can switch from one server to another. You can order
-		it for any Hetzner dedicated root server, and you can switch it to any other Hetzner dedicated
-		root server, regardless of location.
-
-		Switching a Failover IP takes between 90 and 110 seconds.
-
-		REFERENCE : https://docs.hetzner.com/robot/dedicated-server/ip/failover/.
-	*/
-	// Hetzner Robot Failover IP API spec : https://robot.hetzner.com/doc/webservice/en.html#failover.
-
-	// Get IP address of the server, the Failover IP is currently pointing to.
-	activeServerIP := getActiveServerIP(ctx, httpClient, args.FailoverIP)
-	slog.InfoContext(ctx, "Detected active server", slog.String("ip", activeServerIP))
-
-	if activeServerIP == args.ServerIP {
-		slog.InfoContext(ctx, "Active server IP is already same as the current server IP")
-		return
+	// The Robot Failover API only accepts the target server's public main IP as active_server_ip.
+	// Resolve this node's ExternalIP (its public main IP) from the Kubernetes API. This is NOT the
+	// same as the pod's status.hostIP, which is the private vSwitch IP when kubelet runs with
+	// --node-ip set to the internal network.
+	targetServerIP, err := kube.GetNodeExternalIP(ctx, args.NodeName)
+	if err != nil {
+		return fmt.Errorf("resolving the public IP of node %q: %w", args.NodeName, err)
 	}
 
-	// Update Failover IP to the current node's IP (the current node, on which this script is
-	// running)
-	switchFailoverIP(ctx, httpClient, args.FailoverIP, args.ServerIP)
+	// Get the IP address of the server the Failover IP currently points to.
+	activeServerIP, err := getActiveServerIP(ctx, httpClient, args.FailoverIP)
+	if err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "Detected active server",
+		slog.String("ip", activeServerIP),
+		slog.String("node", args.NodeName),
+		slog.String("nodeExternalIP", targetServerIP),
+	)
+
+	if activeServerIP == targetServerIP {
+		slog.InfoContext(ctx, "Failover IP already points to this node's public IP; nothing to do")
+		return nil
+	}
+
+	// Update the Failover IP to the current node's public IP.
+	return switchFailoverIP(ctx, httpClient, args.FailoverIP, targetServerIP)
 }
 
-type (
-	GetFailoverResponse struct {
-		Failover struct {
-			ActiveServerIP string `json:"active_server_ip"`
-		} `json:"failover"`
-	}
-)
+type GetFailoverResponse struct {
+	Failover struct {
+		ActiveServerIP string `json:"active_server_ip"`
+	} `json:"failover"`
+}
 
-// Returns the IP address of the server, the given Failover IP is pointing to.
-func getActiveServerIP(ctx context.Context, httpClient *resty.Client, failoverIP string) string {
+// getActiveServerIP returns the IP address of the server the given Failover IP points to.
+func getActiveServerIP(ctx context.Context, httpClient *resty.Client, failoverIP string) (string, error) {
 	response, err := httpClient.NewRequest().
+		SetContext(ctx).
 		SetHeader("Accept", "application/json").
 		Get("/failover/" + failoverIP)
-
-	assert.AssertErrNil(ctx, err, "Failed getting Failover IP details")
-	assert.Assert(ctx, response.StatusCode() == http.StatusOK, "Failed getting Failover IP details")
+	if err != nil {
+		return "", fmt.Errorf("getting Failover IP %q details: %w", failoverIP, err)
+	}
+	if response.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("getting Failover IP %q details: unexpected status %d: %s",
+			failoverIP, response.StatusCode(), response.String())
+	}
 
 	var unmarshalledResponse GetFailoverResponse
-	err = json.Unmarshal(response.Body(), &unmarshalledResponse)
-	assert.AssertErrNil(ctx, err, "Failed unmarshalling Failover IP details")
+	if err := json.Unmarshal(response.Body(), &unmarshalledResponse); err != nil {
+		return "", fmt.Errorf("decoding Failover IP %q details: %w", failoverIP, err)
+	}
 
-	return unmarshalledResponse.Failover.ActiveServerIP
+	return unmarshalledResponse.Failover.ActiveServerIP, nil
 }
 
-// Makes the Failover IP point to the given server.
-func switchFailoverIP(ctx context.Context, httpClient *resty.Client, failoverIP, targetServerIP string) {
+// switchFailoverIP makes the Failover IP point to the given server.
+func switchFailoverIP(ctx context.Context, httpClient *resty.Client, failoverIP, targetServerIP string) error {
 	response, err := httpClient.NewRequest().
+		SetContext(ctx).
 		SetHeader("Content-Type", "application/x-www-form-urlencoded").
+		SetHeader("Accept", "application/json").
 		SetFormData(map[string]string{
 			"active_server_ip": targetServerIP,
 		}).
-		SetHeader("Accept", "application/json").
 		Post("/failover/" + failoverIP)
-
-	assert.AssertErrNil(ctx, err, "Failed switching Failover IP to the current node IP")
-	assert.Assert(ctx,
-		response.StatusCode() == http.StatusOK,
-		"Failed switching Failover IP to the current node IP",
-		slog.Any("response", response),
-	)
+	if err != nil {
+		return fmt.Errorf("switching Failover IP %q to %q: %w", failoverIP, targetServerIP, err)
+	}
+	if response.StatusCode() != http.StatusOK {
+		return fmt.Errorf("switching Failover IP %q to %q: unexpected status %d: %s",
+			failoverIP, targetServerIP, response.StatusCode(), response.String())
+	}
 
 	slog.InfoContext(ctx,
 		"Successfully updated Failover IP",
 		slog.String("active-server-ip", targetServerIP),
 	)
+	return nil
 }

--- a/hetzner-failover-script/pkg/kube/node.go
+++ b/hetzner-failover-script/pkg/kube/node.go
@@ -1,0 +1,90 @@
+package kube
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/go-resty/resty/v2"
+)
+
+const (
+	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	serviceAccountCAPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
+
+// NodeAddress mirrors a single entry of a Kubernetes Node's status.addresses.
+type NodeAddress struct {
+	Type    string `json:"type"`
+	Address string `json:"address"`
+}
+
+type nodeResponse struct {
+	Status struct {
+		Addresses []NodeAddress `json:"addresses"`
+	} `json:"status"`
+}
+
+// SelectExternalIP returns the ExternalIP from a Node's status.addresses.
+//
+// For Hetzner dedicated (Robot) servers this is the server's public main IP —
+// the only address the Robot Failover API accepts as active_server_ip. The
+// node's status.hostIP, by contrast, is the (private) vSwitch IP when kubelet
+// runs with --node-ip set to the internal network.
+func SelectExternalIP(addresses []NodeAddress) (string, error) {
+	for _, address := range addresses {
+		if address.Type == "ExternalIP" {
+			return address.Address, nil
+		}
+	}
+
+	return "", fmt.Errorf("no ExternalIP found among %d node address(es)", len(addresses))
+}
+
+// GetNodeExternalIP looks up the given Node through the in-cluster Kubernetes
+// API and returns its ExternalIP. It authenticates with the pod's mounted
+// ServiceAccount token and verifies the API server against the mounted cluster
+// CA, so the pod's ServiceAccount needs RBAC to "get" nodes.
+func GetNodeExternalIP(ctx context.Context, nodeName string) (string, error) {
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	if len(host) == 0 || len(port) == 0 {
+		return "", fmt.Errorf("not running in-cluster: KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT are unset")
+	}
+
+	token, err := os.ReadFile(serviceAccountTokenPath)
+	if err != nil {
+		return "", fmt.Errorf("reading ServiceAccount token: %w", err)
+	}
+
+	httpClient := resty.New().
+		SetBaseURL("https://" + net.JoinHostPort(host, port)).
+		SetRootCertificate(serviceAccountCAPath).
+		SetAuthToken(string(token))
+
+	response, err := httpClient.NewRequest().
+		SetContext(ctx).
+		SetHeader("Accept", "application/json").
+		Get("/api/v1/nodes/" + nodeName)
+	if err != nil {
+		return "", fmt.Errorf("requesting node %q from the Kubernetes API: %w", nodeName, err)
+	}
+	if response.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("requesting node %q from the Kubernetes API: unexpected status %d: %s",
+			nodeName, response.StatusCode(), response.String())
+	}
+
+	var node nodeResponse
+	if err := json.Unmarshal(response.Body(), &node); err != nil {
+		return "", fmt.Errorf("decoding node %q response: %w", nodeName, err)
+	}
+
+	externalIP, err := SelectExternalIP(node.Status.Addresses)
+	if err != nil {
+		return "", fmt.Errorf("node %q: %w", nodeName, err)
+	}
+
+	return externalIP, nil
+}

--- a/hetzner-failover-script/pkg/kube/node_test.go
+++ b/hetzner-failover-script/pkg/kube/node_test.go
@@ -1,0 +1,30 @@
+package kube
+
+import "testing"
+
+func TestSelectExternalIPReturnsExternalIPAmongMixedAddresses(t *testing.T) {
+	addresses := []NodeAddress{
+		{Type: "InternalIP", Address: "10.0.0.2"},
+		{Type: "Hostname", Address: "node-1"},
+		{Type: "ExternalIP", Address: "203.0.113.10"},
+	}
+
+	got, err := SelectExternalIP(addresses)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "203.0.113.10" {
+		t.Fatalf("SelectExternalIP() = %q, want %q", got, "203.0.113.10")
+	}
+}
+
+func TestSelectExternalIPErrorsWhenNoExternalIPPresent(t *testing.T) {
+	addresses := []NodeAddress{
+		{Type: "InternalIP", Address: "10.0.0.2"},
+		{Type: "Hostname", Address: "node-1"},
+	}
+
+	if _, err := SelectExternalIP(addresses); err == nil {
+		t.Fatal("expected an error when no ExternalIP is present, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

`hetzner-robot-failover` sits in CrashLoopBackOff (900+ restarts observed). The Hetzner Robot Failover API only accepts a dedicated server's **public main IP** as `active_server_ip`, but `SERVER_IP` was sourced from the downward-API `status.hostIP` — which is the **private vSwitch IP** (RFC1918) when kubelet runs with `--node-ip` on the internal network. Every reconcile POSTed that private IP and got:

```
404 {"error":{"status":404,"code":"FAILOVER_NEW_SERVER_NOT_FOUND","message":"new server not found"}}
```

and `os.Exit(1)` turned each failure into a crash.

## Fix

- **New `pkg/kube` package** — resolve the node's `ExternalIP` (its public main IP) via the in-cluster Kubernetes API: `NODE_NAME` (from `spec.nodeName`) + the mounted ServiceAccount token/CA, reusing the existing `resty` dependency (no client-go pulled in).
- **`pkg/hetzner`** — use the resolved ExternalIP as the failover target. API/HTTP errors now **return** (logged and retried on the next interval) instead of `os.Exit(1)`, so a transient or misconfigured call no longer crash-loops the process.
- **`cmd/main.go`** — `SERVER_IP` → `NODE_NAME`.

## Requires

- RBAC to `get nodes` — added in the companion KubeAid `hetzner-robot` chart change.
- After merge, tag the repo **`v1.2.0`** so CI publishes `ghcr.io/obmondo/hetzner-failover-script:v1.2.0`; the chart pins that tag.

## Tests

- `pkg/kube/node_test.go` covers the ExternalIP-selection logic (written test-first).
- `go build ./... && go vet ./... && go test ./...` all green; `gofmt` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)