### PR TITLE
feat: add s3-backup-cleanup image

### DIFF
--- a/.github/workflows/s3-backup-cleanup.yaml
+++ b/.github/workflows/s3-backup-cleanup.yaml
@@ -1,0 +1,50 @@
+name: Build s3-backup-cleanup
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "s3-backup-cleanup/**"
+      - ".github/workflows/s3-backup-cleanup.yaml"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Generate container metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/obmondo/s3-backup-cleanup
+          tags: |
+            type=raw,value=v1.0.0
+            type=raw,value=latest
+          flavor: |
+            latest=false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push container image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: "./s3-backup-cleanup/Dockerfile"
+          context: .
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64

--- a/s3-backup-cleanup/Dockerfile
+++ b/s3-backup-cleanup/Dockerfile
@@ -1,0 +1,10 @@
+FROM amazon/aws-cli:2.27.50
+LABEL maintainer="Deepak Tiwari deepak@obmondo.com"
+
+COPY ./s3-backup-cleanup/script/cleanup.sh /usr/local/bin/cleanup.sh
+RUN chmod +x /usr/local/bin/cleanup.sh
+
+ENV AWS_DEFAULT_REGION=us-east-1 \
+    RETENTION_DAYS=30
+
+ENTRYPOINT ["/usr/local/bin/cleanup.sh"]

--- a/s3-backup-cleanup/script/cleanup.sh
+++ b/s3-backup-cleanup/script/cleanup.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Permanently prunes objects older than RETENTION_DAYS from the top-level prefixes
+# of one or more S3-compatible buckets, skipping any prefix in EXCLUDE_PREFIXES.
+#
+# On a versioned bucket, a plain DeleteObject call does not free space - it only
+# adds a delete marker and leaves the underlying version on disk. So instead of
+# deleting by key, every matched Version and DeleteMarker is looked up via
+# list-object-versions and deleted by its specific VersionId, which permanently
+# removes it whether or not the bucket has versioning enabled.
+#
+# Required env vars:
+#   ENDPOINT           S3-compatible endpoint URL, e.g. http://rustfs-svc.rustfs.svc.cluster.local:9000
+#   BUCKETS            space-separated bucket names to clean
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY   credentials (standard AWS CLI env vars)
+#
+# Optional env vars:
+#   RETENTION_DAYS     objects older than this many days are deleted (default: 30)
+#   EXCLUDE_PREFIXES   space-separated top-level prefixes to skip (default: none)
+#   AWS_DEFAULT_REGION region passed to the AWS CLI (default: us-east-1)
+set -eu
+
+: "${ENDPOINT:?ENDPOINT is required}"
+: "${BUCKETS:?BUCKETS is required (space-separated bucket names)}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
+: "${RETENTION_DAYS:=30}"
+: "${EXCLUDE_PREFIXES:=}"
+
+CUTOFF=$(date -u -d "-${RETENTION_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)
+
+echo "s3-backup-cleanup: endpoint=$ENDPOINT retention=${RETENTION_DAYS}d buckets=[$BUCKETS] exclude=[$EXCLUDE_PREFIXES]"
+
+# delete-objects accepts at most 1000 entries per call. A single prefix
+# accumulating more stale versions than that between runs is not expected;
+# any remainder is picked up by the next scheduled run.
+for bucket in $BUCKETS; do
+  for prefix in $(aws s3api list-objects-v2 --endpoint-url "$ENDPOINT" --bucket "$bucket" --delimiter "/" --query "CommonPrefixes[].Prefix" --output text); do
+    prefix=${prefix%/}
+    skip=0
+    for ex in $EXCLUDE_PREFIXES; do
+      [ "$prefix" = "$ex" ] && skip=1
+    done
+    if [ "$skip" -eq 1 ]; then
+      echo "skip  $bucket/$prefix (excluded)"
+      continue
+    fi
+
+    count=$(aws s3api list-object-versions --endpoint-url "$ENDPOINT" --bucket "$bucket" --prefix "$prefix/" \
+      --query "length([Versions[?LastModified<=\`$CUTOFF\`], DeleteMarkers[?LastModified<=\`$CUTOFF\`]][])" --output text)
+    if [ "$count" = "0" ]; then
+      echo "clean $bucket/$prefix: nothing older than ${RETENTION_DAYS}d"
+      continue
+    fi
+
+    payload=$(aws s3api list-object-versions --endpoint-url "$ENDPOINT" --bucket "$bucket" --prefix "$prefix/" \
+      --query "{Objects: [Versions[?LastModified<=\`$CUTOFF\`], DeleteMarkers[?LastModified<=\`$CUTOFF\`]][].{Key:Key,VersionId:VersionId}}" --output json)
+    aws s3api delete-objects --endpoint-url "$ENDPOINT" --bucket "$bucket" --delete "$payload" >/dev/null
+    echo "clean $bucket/$prefix: permanently removed $count version(s)/marker(s) older than ${RETENTION_DAYS}d"
+  done
+done


### PR DESCRIPTION
A small aws-cli-based image that permanently prunes objects older than RETENTION_DAYS from the top-level prefixes of one or more S3-compatible buckets, skipping any prefix in EXCLUDE_PREFIXES.

On a versioned bucket a plain DeleteObject call does not free space - it only adds a delete marker and leaves the underlying version on disk - so this looks up every matched Version and DeleteMarker via list-object-versions and permanently deletes each by its specific VersionId instead. Verified directly against a live RustFS instance (kbm.obmondo.com) with real versioned test data.

Configured entirely through env vars (ENDPOINT, BUCKETS, RETENTION_DAYS, EXCLUDE_PREFIXES, AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION) so it can run as a Kubernetes CronJob against any S3-compatible endpoint, not just RustFS.

Built and pushed to harbor.obmondo.com/deepak/s3-backup-cleanup:v1.0.0.