### PR TITLE
fix(s3-backup-cleanup): batch deletes instead of one argv payload

### DIFF
--- a/.github/workflows/s3-backup-cleanup.yaml
+++ b/.github/workflows/s3-backup-cleanup.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           images: ghcr.io/obmondo/s3-backup-cleanup
           tags: |
-            type=raw,value=v1.0.0
+            type=raw,value=v1.0.1
             type=raw,value=latest
           flavor: |
             latest=false

--- a/s3-backup-cleanup/script/cleanup.sh
+++ b/s3-backup-cleanup/script/cleanup.sh
@@ -17,6 +17,9 @@
 #   RETENTION_DAYS     objects older than this many days are deleted (default: 30)
 #   EXCLUDE_PREFIXES   space-separated top-level prefixes to skip (default: none)
 #   AWS_DEFAULT_REGION region passed to the AWS CLI (default: us-east-1)
+#   BATCH_SIZE         versions per delete-objects call, max 1000 (default: 1000)
+#   PAGE_SIZE          versions per list-object-versions request (default: 1000)
+#   WORKDIR            scratch directory for batch files (default: ${TMPDIR:-/tmp})
 set -eu
 
 : "${ENDPOINT:?ENDPOINT is required}"
@@ -25,14 +28,35 @@ set -eu
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
 : "${RETENTION_DAYS:=30}"
 : "${EXCLUDE_PREFIXES:=}"
+: "${BATCH_SIZE:=1000}"
+: "${PAGE_SIZE:=1000}"
+: "${WORKDIR:=${TMPDIR:-/tmp}}"
 
 CUTOFF=$(date -u -d "-${RETENTION_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)
 
+SCRATCH=$(mktemp -d "${WORKDIR%/}/s3-backup-cleanup.XXXXXX")
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+
 echo "s3-backup-cleanup: endpoint=$ENDPOINT retention=${RETENTION_DAYS}d buckets=[$BUCKETS] exclude=[$EXCLUDE_PREFIXES]"
 
-# delete-objects accepts at most 1000 entries per call. A single prefix
-# accumulating more stale versions than that between runs is not expected;
-# any remainder is picked up by the next scheduled run.
+# Renders TAB-separated "Key<TAB>VersionId" lines as a DeleteObjects request
+# body. Passing the request as a file keeps it off the argument vector: a prefix
+# with a few thousand stale versions produces well over the 128 KiB the kernel
+# allows for a single argv entry (MAX_ARG_STRLEN), which is why building the
+# payload inline used to abort the run with "Argument list too long".
+render_batch() {
+  awk -F'\t' -v bucket="$1" '
+    function json(s) {
+      gsub(/\\/, "\\\\", s)
+      gsub(/"/, "\\\"", s)
+      return s
+    }
+    BEGIN { printf "{\"Bucket\":\"%s\",\"Delete\":{\"Quiet\":true,\"Objects\":[", json(bucket) }
+    { printf "%s{\"Key\":\"%s\",\"VersionId\":\"%s\"}", (NR > 1 ? "," : ""), json($1), json($2) }
+    END { print "]}}" }
+  '
+}
+
 for bucket in $BUCKETS; do
   for prefix in $(aws s3api list-objects-v2 --endpoint-url "$ENDPOINT" --bucket "$bucket" --delimiter "/" --query "CommonPrefixes[].Prefix" --output text); do
     prefix=${prefix%/}
@@ -45,16 +69,42 @@ for bucket in $BUCKETS; do
       continue
     fi
 
-    count=$(aws s3api list-object-versions --endpoint-url "$ENDPOINT" --bucket "$bucket" --prefix "$prefix/" \
-      --query "length([Versions[?LastModified<=\`$CUTOFF\`], DeleteMarkers[?LastModified<=\`$CUTOFF\`]][])" --output text)
-    if [ "$count" = "0" ]; then
+    # --page-size bounds each ListObjectVersions request; the CLI still walks
+    # every page. Without it the server is asked for the whole prefix in one
+    # response, which some S3 implementations answer too slowly to complete.
+    aws s3api list-object-versions --endpoint-url "$ENDPOINT" --bucket "$bucket" --prefix "$prefix/" \
+      --page-size "$PAGE_SIZE" \
+      --query "[Versions[?LastModified<=\`$CUTOFF\`], DeleteMarkers[?LastModified<=\`$CUTOFF\`]][].[Key,VersionId]" \
+      --output text > "$SCRATCH/raw"
+
+    # Drop the "None" the CLI prints for an empty result, and any line the
+    # query did not fill in completely.
+    awk -F'\t' 'NF == 2 && $1 != "None" && $2 != "None"' "$SCRATCH/raw" > "$SCRATCH/versions"
+
+    count=$(wc -l < "$SCRATCH/versions")
+    if [ "$count" -eq 0 ]; then
       echo "clean $bucket/$prefix: nothing older than ${RETENTION_DAYS}d"
       continue
     fi
 
-    payload=$(aws s3api list-object-versions --endpoint-url "$ENDPOINT" --bucket "$bucket" --prefix "$prefix/" \
-      --query "{Objects: [Versions[?LastModified<=\`$CUTOFF\`], DeleteMarkers[?LastModified<=\`$CUTOFF\`]][].{Key:Key,VersionId:VersionId}}" --output json)
-    aws s3api delete-objects --endpoint-url "$ENDPOINT" --bucket "$bucket" --delete "$payload" >/dev/null
+    # DeleteObjects accepts at most 1000 entries per call, so split rather than
+    # leaving the remainder to the next scheduled run - a prefix that grows
+    # faster than one run removes would never converge.
+    rm -rf "$SCRATCH/batches"
+    mkdir -p "$SCRATCH/batches"
+    split -l "$BATCH_SIZE" "$SCRATCH/versions" "$SCRATCH/batches/batch."
+
+    for batch in "$SCRATCH"/batches/batch.*; do
+      render_batch "$bucket" < "$batch" > "$batch.json"
+      errors=$(aws s3api delete-objects --endpoint-url "$ENDPOINT" --cli-input-json "file://$batch.json")
+      # Quiet mode returns nothing on success and an Errors array otherwise.
+      if [ -n "$errors" ]; then
+        echo "error $bucket/$prefix: delete-objects reported failures" >&2
+        echo "$errors" >&2
+        exit 1
+      fi
+    done
+
     echo "clean $bucket/$prefix: permanently removed $count version(s)/marker(s) older than ${RETENTION_DAYS}d"
   done
 done


### PR DESCRIPTION
rustfs-backup-cleanup on kbm.obmondo.com has failed every night since 2026-08-25 with:

  /usr/local/bin/cleanup.sh: line 57: /usr/local/bin/aws: Argument list too long

The script built the entire DeleteObjects body with --output json and passed it to `aws s3api delete-objects --delete "$payload"` as a single argument. The kernel caps one argv entry at 128 KiB (MAX_ARG_STRLEN), so the run died on the first prefix large enough to exceed it. On kbm that is velero-backup with ~8.7k objects; the smaller sealed-secret (85) and spilo (534) prefixes cleaned successfully first, which is why the job appeared to work for weeks.

The 1000-entry cap noted above the loop was also only a comment - nothing enforced it, and DeleteObjects rejects more than 1000 entries per call. The claim that "any remainder is picked up by the next scheduled run" does not hold either: a prefix growing faster than one run removes never converges.

Stream the matched versions to a file as Key/VersionId pairs, split into batches of at most 1000, render each batch with awk (the aws-cli image has no jq or python3) and hand it over with --cli-input-json file://, keeping the payload off the argument vector entirely.

Two smaller fixes while here:

- Pass --page-size so each ListObjectVersions request is bounded. The other failure seen on kbm was "ListObjectVersions (reached max retries: 2): Io error: timeout" - rustfs could not answer a whole-prefix listing in time.
- Drop the separate length() query. It listed the entire prefix a second time purely to produce a count that the listing itself already gives.

Verified against MinIO with versioning enabled and 2500 objects under one prefix: the old script reproduces "Argument list too long" at line 57, the new one removes 2590 versions and markers in three batches, honours EXCLUDE_PREFIXES, and correctly escapes keys containing quotes and spaces.

Bump the published tag to v1.0.1 - the workflow pins a fixed tag, and rebuilding v1.0.0 in place would not be re-pulled by nodes running imagePullPolicy: IfNotPresent.